### PR TITLE
Fix future date bug in date rendering

### DIFF
--- a/src/craft/BreakingNews.py
+++ b/src/craft/BreakingNews.py
@@ -126,7 +126,7 @@ def create_newspaper_image(
         draw,
         day_of_week(days_into_future=days_into_future)
         + " "
-        + shamsi(year=True, month=True, day=True),
+        + shamsi(year=True, month=True, day=True, days_into_future=days_into_future),
         fonts["persian_date"],
         *positions["persian_date"],
         alignment="right",

--- a/src/craft/Live.py
+++ b/src/craft/Live.py
@@ -144,7 +144,7 @@ def create_newspaper_image(
         draw,
         day_of_week(days_into_future=days_into_future)
         + " "
-        + shamsi(year=True, month=True, day=True),
+        + shamsi(year=True, month=True, day=True, days_into_future=days_into_future),
         fonts["persian_date"],
         *positions["persian_date"],
         alignment="right",

--- a/src/craft/Post.py
+++ b/src/craft/Post.py
@@ -146,7 +146,7 @@ def create_newspaper_image(
         draw,
         day_of_week(days_into_future=days_into_future)
         + " "
-        + shamsi(year=True, month=True, day=True),
+        + shamsi(year=True, month=True, day=True, days_into_future=days_into_future),
         fonts["persian_date"],
         *positions["persian_date"],
         alignment="right",

--- a/src/craft/Post2.0.py
+++ b/src/craft/Post2.0.py
@@ -142,7 +142,7 @@ def create_newspaper_image(
         draw,
         day_of_week(days_into_future=days_into_future)
         + " "
-        + shamsi(year=True, month=True, day=True),
+        + shamsi(year=True, month=True, day=True, days_into_future=days_into_future),
         fonts["persian_date"],
         *positions["persian_date"],
         alignment="right",

--- a/src/craft/screenshot.py
+++ b/src/craft/screenshot.py
@@ -209,7 +209,7 @@ def create_newspaper_image(
         draw,
         day_of_week(days_into_future=days_into_future)
         + " "
-        + shamsi(year=True, month=True, day=True),
+        + shamsi(year=True, month=True, day=True, days_into_future=days_into_future),
         fonts["persian_date"],
         *positions["persian_date"],
         alignment="right",


### PR DESCRIPTION
## Summary
- fix shamsi date offset across newspaper generators

## Testing
- `python3 -m py_compile src/craft/BreakingNews.py src/craft/Post.py src/craft/Post2.0.py src/craft/Live.py src/craft/screenshot.py`
- `python3 -m py_compile src/craft/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff6d41e98832db395ba85070be72d